### PR TITLE
fix #1: resolve potential buff overflow

### DIFF
--- a/src/ocre/api/ocre_api.c
+++ b/src/ocre/api/ocre_api.c
@@ -4,6 +4,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#define _GNU_SOURCE
 
 #include <stdio.h>
 #include <sys/utsname.h>
@@ -31,33 +32,33 @@ int _ocre_posix_uname(wasm_exec_env_t exec_env, struct _ocre_posix_utsname *name
 
     memset(name, 0, sizeof(struct _ocre_posix_utsname));
 
-    sprintf(name->sysname, "%s (%s)", OCRE_SYSTEM_NAME, info.sysname);
-    sprintf(name->release, "%s (%s)", APP_VERSION_STRING, info.release);
-    sprintf(name->version, "%s", info.version);
+    snprintf(name->sysname, OCRE_API_POSIX_BUF_SIZE, "%s (%s)", OCRE_SYSTEM_NAME, info.sysname);
+    snprintf(name->release, OCRE_API_POSIX_BUF_SIZE, "%s (%s)", APP_VERSION_STRING, info.release);
+    snprintf(name->version, OCRE_API_POSIX_BUF_SIZE, "%s", info.version);
 
 // ARM Processors are special cased as they are so popular
 #ifdef CONFIG_ARM
 #ifdef CONFIG_CPU_CORTEX_M0
-    strcpy(name->machine, "ARM Cortex-M0");
+    strlcat(name->machine, "ARM Cortex-M0", OCRE_API_POSIX_BUF_SIZE);
 #elif CONFIG_CPU_CORTEX_M3
-    strcpy(name->machine, "ARM Cortex-M3");
+    strlcat(name->machine, "ARM Cortex-M3", OCRE_API_POSIX_BUF_SIZE);
 #elif CONFIG_CPU_CORTEX_M4
-    strcpy(name->machine, "ARM Cortex-M4");
+    strlcat(name->machine, "ARM Cortex-M4", OCRE_API_POSIX_BUF_SIZE);
 #elif CONFIG_CPU_CORTEX_M7
-    strcpy(name->machine, "ARM Cortex-M7");
+    strlcat(name->machine, "ARM Cortex-M7", OCRE_API_POSIX_BUF_SIZE);
 #elif CONFIG_CPU_CORTEX_M33
-    strcpy(name->machine, "ARM Cortex-M33");
+    strlcat(name->machine, "ARM Cortex-M33", OCRE_API_POSIX_BUF_SIZE);
 #elif CONFIG_CPU_CORTEX_M23
-    strcpy(name->machine, "ARM Cortex-M23");
+    strlcat(name->machine, "ARM Cortex-M23", OCRE_API_POSIX_BUF_SIZE);
 #elif CONFIG_CPU_CORTEX_M55
-    strcpy(name->machine, "ARM Cortex-M55");
+    strlcat(name->machine, "ARM Cortex-M55", OCRE_API_POSIX_BUF_SIZE);
 #endif
 #else
     // Other processors, use value returned from uname()
-    strcpy(name->machine, info.machine);
+    strlcat(name->machine, info.machine, OCRE_API_POSIX_BUF_SIZE);
 #endif
 
-    strcpy(name->nodename, info.nodename);
+    strlcat(name->nodename, info.nodename, OCRE_API_POSIX_BUF_SIZE);
 
     return 0;
 }

--- a/src/ocre/api/ocre_api.h
+++ b/src/ocre/api/ocre_api.h
@@ -10,17 +10,19 @@
 #ifndef OCRE_API_H
 #define OCRE_API_H
 
+#define OCRE_API_POSIX_BUF_SIZE 75
+
 #ifndef OCRE_SYSTEM_NAME
 #define OCRE_SYSTEM_NAME "Project Ocre"
 #endif
 
 struct _ocre_posix_utsname {
-    char sysname[65];
-    char nodename[65];
-    char release[65];
-    char version[65];
-    char machine[65];
-    char domainname[65];
+    char sysname[OCRE_API_POSIX_BUF_SIZE];
+    char nodename[OCRE_API_POSIX_BUF_SIZE];
+    char release[OCRE_API_POSIX_BUF_SIZE];
+    char version[OCRE_API_POSIX_BUF_SIZE];
+    char machine[OCRE_API_POSIX_BUF_SIZE];
+    char domainname[OCRE_API_POSIX_BUF_SIZE];
 };
 
 int _ocre_posix_uname(wasm_exec_env_t exec_env, struct _ocre_posix_utsname *name);


### PR DESCRIPTION
-) subs out strcpy for strlcat. and snprintf for sprintf
  -) fixes potential buf overflow on native target where info.version is 70 char
-) bumps up buffer size to fit info.version