### PR TITLE
ocre-tests: make workflows run one at a time

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,33 +1,31 @@
 name: Tests
 on:
-    push:
-      branches:
-          - main
-    pull_request:
-        branches:
-            - main
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
 jobs:
-    tests:
-        runs-on: zephyr-xlarge-runner
+  tests:
+      runs-on: zephyr-xlarge-runner
 
-        steps:
-            - name: Make the github actions runner recursively take ownership of the github workspace
-              run: sudo chown -R $(whoami) ${{ github.workspace }}
+      steps:
+          - name: Make the github actions runner recursively take ownership of the github workspace
+            run: sudo chown -R $(whoami) ${{ github.workspace }}
 
-            - name: Checkout
-              uses: actions/checkout@v4
-      
-            - name: Flash Validation Tests
-              run: |
-                  cd tests && bash beginTests.sh "flashValidation"
+          - name: Checkout
+            uses: actions/checkout@v4
+    
+          - name: Flash Validation Tests
+            run: |
+              cd tests && bash beginTests.sh "flashValidation"
 
-            - name: Print Flash Validation Logs
-              if: always()
-              run: cat /tmp/flashValidation.log
-            
-            - name: Upload log file as artifact
-              if: always()
-              uses: actions/upload-artifact@v4
-              with:
-                  name: "FlashValidation.log"
-                  path: /tmp/flashValidation.log
+          - name: Print Flash Validation Logs
+            if: always()
+            run: cat /tmp/flashValidation.log
+          
+          - name: Upload log file as artifact
+            if: always()
+            uses: actions/upload-artifact@v4
+            with:
+                name: "FlashValidation.log"
+                path: /tmp/flashValidation.log

--- a/tests/beginTests.sh
+++ b/tests/beginTests.sh
@@ -110,4 +110,10 @@ done
 
 echo "Test suite is complete" >> $LOGFILE
 
+if [ $TEST_GROUP_RESULT -eq 0 ]; then
+    echo "$NAME test group passed"
+else
+    echo "$NAME test group failed"
+fi
+
 exit $TEST_GROUP_RESULT


### PR DESCRIPTION
Force the tests.yml to wait on GHA build.yml to complete before triggering.

# Description

This PR adds the usage of the workflow_run syntax in order to ensure that when a PR is created targeting main, build.yml will run to completion first, and then tests.yml will run. 

https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run

This PR also adds an additional echo at the end of beginTests.sh which indicates what the overall result of the test group was. Knox had requested this since from the GHA web interface side, when the tests failed all that was printed was something like "exited with non-zero exit code."

## Type of change

Please delete options that are not relevant.

- [x] Test Coverage update

# How Has This Been Tested?

This feature does not work UNTIL it has been merged to main, so you will not see proof of it running until the first PR which is created after this is merged. However, I do have "proof" of it working from my ocre-runtime fork, where I merged it to main, then made a simple README update on a feature branch, created a PR targetting main, and the workflow_run trigger worked as expected.

build: https://github.com/PatrickRobbIOL/ocre-runtime/actions/runs/14626332720
tests: https://github.com/PatrickRobbIOL/ocre-runtime/actions/runs/14626408465