### PR TITLE
fix(posix): argc count argument parsing

### DIFF
--- a/src/shared/platform/posix/core_fs.c
+++ b/src/shared/platform/posix/core_fs.c
@@ -23,7 +23,7 @@ int core_construct_filepath(char *path, size_t len, char *name) {
     char cwd[PATH_MAX];
     if (getcwd(cwd, sizeof(cwd)) != NULL) 
        printf("Current working dir: %s\n", cwd);
-    if (g_argc) {
+    if (g_argc>1) {
         strcpy(path, name);
         return 0;
     } else {


### PR DESCRIPTION

# Description

If no arguments are passed, argc is 1.

We fix this by comparing with the correct value 1

- Fixes issue: if you run without any parameters it will not find the default hello.bin file.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested by hand in NuttX

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes