### PR TITLE
Namespace generated zephyr headers

### DIFF
--- a/src/ocre/api/ocre_common.c
+++ b/src/ocre/api/ocre_common.c
@@ -15,7 +15,7 @@
 #include <stdlib.h>
 #include <string.h>
 LOG_MODULE_DECLARE(ocre_cs_component, OCRE_LOG_LEVEL);
-#include <autoconf.h>
+#include <zephyr/autoconf.h>
 #include "../../../../../wasm-micro-runtime/core/iwasm/include/lib_export.h"
 #include "bh_log.h"
 #include "../ocre_timers/ocre_timer.h"

--- a/src/shared/platform/zephyr/core_internal.h
+++ b/src/shared/platform/zephyr/core_internal.h
@@ -15,9 +15,9 @@
 #include <zephyr/device.h>
 #include <zephyr/kernel/mm.h>
 
-#include <version.h>
-#include <app_version.h>
-#include <autoconf.h>
+#include <zephyr/version.h>
+#include <zephyr/app_version.h>
+#include <zephyr/autoconf.h>
 
 // clang-format off
 


### PR DESCRIPTION
# Description

> **Problem description**
> Some of the generated headers have pretty generic names, i.e.: version.h, and can potentially conflict with other library / user applications. Ideally, all Zephyr's headers, in-tree or generated, should be namespaced with zephyr/.
> 
> **Proposed change**
> To avoid potential conflicts with other library or user application headers due to generic names, introduce a zephyr/ namespace for all Zephyr-generated and in-tree headers. This can be achieved by modifying the CMake files and scripts responsible for generating these headers to include the zephyr/ prefix in their file names and updating the include paths in source files accordingly.
> 
> Additionally, ensure that the legacy include paths remains compatible during this transition and update the migration and release notes with details about this change and any necessary mitigation steps for users.

Please check: https://github.com/zephyrproject-rtos/zephyr/issues/73114

Relevant migration notes: https://docs.zephyrproject.org/latest/releases/migration-guide-3.7.html#build-system

Real-time issue: 
While trying to build modern zephyr (4.2) with  --sysbuild (check this: https://docs.zephyrproject.org/latest/build/sysbuild/index.html) , following error is thrown:
```bash
fatal error: autoconf.h: No such file or directory
   10 | #include <autoconf.h>
      |          ^~~~~~~~~~~~
compilation terminated.
```
because it hasn't been generated yet. 

This PR solves this issue and follows earlier migration guide.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code cleanup/refactoring

# How Has This Been Tested?
Building with STM32 U585

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes