### PR TITLE
Update CODEOWNERS to change one owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default owners for everything in the repo
-* @srberard @gonzolively
+* @srberard @kr-t


### PR DESCRIPTION
# Description

Update codeowners in order to invite PR reviewers according to the actual status.

## Type of change

No code change - no testing.