### PR TITLE
fix(sample_container): truncate file

### DIFF
--- a/src/samples-mini/zephyr/main.c
+++ b/src/samples-mini/zephyr/main.c
@@ -83,7 +83,7 @@ void create_sample_container(char *file_name) {
     int res;
 
     fs_file_t_init(&f);
-    res = fs_open(&f, file_path, FS_O_CREATE | FS_O_RDWR);
+    res = fs_open(&f, file_path, FS_O_CREATE | FS_O_TRUNC | FS_O_RDWR);
 
     fs_write(&f, &wasm_binary, wasm_binary_len);
     fs_close(&f);


### PR DESCRIPTION
# Description

If there is already a file in the filesystem with the same name and it is larger than the new size we are writing, the file size will not be truncated and we will end up with junk after the end of the wasm buffer.

Use `FS_O_TRUNC`, so that the file will always be truncated to the new size.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. set `OCRE_INPUT_FILE` in CMakeLists.txt to a large wasm file.
2. Flash, and run -> OK
3. set `OCRE_INPUT_FILE` in CMakeLists.txt to a shorter wasm file.
4. Flash and run -> Error: junk sections after the wasm buffer
5. `fs rm /lfs/ocre/images/hello-world.bin`
6. reboot -> OK

After applying this fix, step 4 should be OK also.

**Test Configuration (required)**:
* Host OS type, version, and arch: `Zephyr 4.3`
* Developer Board make & model: `Pimoroni Pico Plus 2W`

But the same problem will happen on any platform.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes