### PR TITLE
tests: add external memory erase step for b_u585 board

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,6 +140,9 @@ jobs:
       - name: Flash b_u585i_iot02a
         if: runner.environment == 'self-hosted'
         run: |
+          STM32_Programmer_CLI -c port=swd -el \
+          "/usr/local/STMicroelectronics/STM32Cube/STM32CubeProgrammer/bin/ExternalLoader/MX25LM51245G_STM32U585I-IOT02A.stldr" \
+          -e all -s
           STM32_Programmer_CLI -c port=swd -e all -w zephyr.bin 0x08000000 -v -rst
 
   build-and-run-linux-sample:


### PR DESCRIPTION
# Description

Per a new Ocre Runtime update, external memory is now used on the B_u585 board. Consequently, we now need to erase this memory before flashing a new container to the board. This PR is adding that needed pre-step.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
I have run the  STM32_Programmer_CLI locally on the zephyr-xlarge-runner at UNH, and it printed to stdout that it had erased the b_u585 board. When this PR is run, we will be able to see if it works also when invoked via GHA.
