### PR TITLE
fix(tests): move to python3 in system tests

### DIFF
--- a/tests/system/posix/CMakeLists.txt
+++ b/tests/system/posix/CMakeLists.txt
@@ -63,7 +63,7 @@ foreach(test ${OCRE_TESTS})
 endforeach()
 
 add_custom_target(run-systests
-    COMMAND python ${CMAKE_CURRENT_LIST_DIR}/../../Unity/auto/unity_test_summary.py ${CMAKE_CURRENT_BINARY_DIR}
+    COMMAND python3 ${CMAKE_CURRENT_LIST_DIR}/../../Unity/auto/unity_test_summary.py ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS
         test_lib.log
         test_ocre.log


### PR DESCRIPTION
# Description

Python as an app is obsolete on some systems, and where isn't, often just linked to python3 anyway. use python3, instead of python in system tests.

- Fixes issue #129 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Local test check, CI

**Test Configuration (required)**:
* Host OS type, version, and arch: `Ubuntu 24.04 (WSL2)`
* Developer Board make & model: `X86_64`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes