### PR TITLE
fix(docs): Update repository URL for Zephyr workspace initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Zephyr workspace initialization:
 
 ```sh
 cd ~/zephyrproject
-west init -m https://github.com/ocre-project/ocre.git
+west init -m https://github.com/project-ocre/ocre-runtime.git
 west update
 west zephyr-export
 ```


### PR DESCRIPTION
# Description

The link in the Readme was wrong. This fixes it. 