### PR TITLE
refactor(demo): reduce b585's external flash size

### DIFF
--- a/src/samples/demo/zephyr/boards/b_u585i_iot02a.overlay
+++ b/src/samples/demo/zephyr/boards/b_u585i_iot02a.overlay
@@ -33,7 +33,7 @@
 
             /* Use the first partition from flash. */
             storage_partition: partition@0 {
-                reg = <0x0 DT_SIZE_M(64)>;
+                reg = <0x0 DT_SIZE_M(16)>;
             };
         };
     };


### PR DESCRIPTION
Currently it takes a lot of time to generate merged hex filesystem. This reduces the generation time, and still gives a lot of memory to a user.

## Type of change

Please delete options that are not relevant.

- [x] Code cleanup/refactoring

# How Has This Been Tested?
CI, building on the board.

**Test Configuration (required)**:
* Host OS type, version, and arch: `Ubuntu 24.04 (amd64)`
* Developer Board make & model: `ST U585`
* Board Tools Installed: `STM32CubeProgrammer`)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes