### PR TITLE
Update build command and sample references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ west sdk install -t \
 Build the sample application:
 
 ```sh
-west build -p always -b b_u585i_iot02a ocre-runtime/src/samples/demo/zephyr
+west build -p always -b b_u585i_iot02a ocre-runtime/src/samples/mini/zephyr
 ```
 
 Connect the board and flash the application:
@@ -112,7 +112,7 @@ Connect the board and flash the application:
 west flash
 ```
 
-Alternatively, you can try the `mini` or `supervisor` samples.
+Alternatively, you can try the `demo` or `supervisor` samples.
 
 ### Full Zephyr build from scratch
 


### PR DESCRIPTION
# Description

Proposal:
mini is the simples sample we can build and it doesn't require anything external or odd (like flashing the merged.hex). In my opinion, mini shall be the very first sample everyone builds, as it probably works on most boards without any additional configuration. 


## Type of change

- [x] Code cleanup/refactoring

# How Has This Been Tested?
Doc change, just the CI

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes