### PR TITLE
refactor(ci): Cleanup the workspace for linux and zephyr builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,6 +22,15 @@ jobs:
       image: ghcr.io/${{ github.repository }}/devcontainer-linux:${{ inputs.devcontainer-tag }}
       options: --user 1000:1000
     steps:
+      - name: Clean workspace
+        run: |
+          git clean -ffdx || true
+          git reset --hard || true
+          git submodule foreach --recursive git clean -ffdx || true
+          git submodule foreach --recursive git reset --hard || true
+          git submodule deinit --all -f || true
+        continue-on-error: true
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -32,14 +32,17 @@ jobs:
           - demo
           - supervisor
     steps:
+      - name: Clean workspace
+        run: |
+          rm -rf ocre-runtime || true
+          rm -rf ../.west || true
+        continue-on-error: true
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           path: ocre-runtime
           submodules: true
-
-      - name: Clean .west directory
-        run: rm -rf ../.west
 
       - name: West init
         run: |
@@ -51,8 +54,9 @@ jobs:
           . /opt/zephyr-venv/bin/activate
           west update
 
-      - name: Clean build directory
-        run: rm -rf build
+      - name: Update submodules
+        run: |
+          git submodule update --init --recursive
 
       - name: West build
         run: |


### PR DESCRIPTION
Due to self-hosted runners' specifics, old garbage might be still there when the new build is happening. Cleanup step would ensure that the workspace is ready.

Additionally, the west update command may be checking out specific versions that don't preserve the submodule state from the initial checkout. The update submodule helps to fix this race condition.