### PR TITLE
docs: Include stdbool.h in Ocre example code

### DIFF
--- a/docs/EmbeddingOcre.md
+++ b/docs/EmbeddingOcre.md
@@ -93,6 +93,7 @@ Now that we have a build working, and we can successfully build Ocre Runtime lib
 
 ```c
 #include <stdio.h>
+#include <stdbool.h>
 #include <ocre/ocre.h>
 
 int main() {


### PR DESCRIPTION
Added include for stdbool.h in main.c example.

We use is here (`false`):
`ocre_context_create_container(ocre, "hello.wasm", "wamr/wasip1", NULL, false, NULL);`