### PR TITLE
Improve workflow for forks

### DIFF
--- a/.github/workflows/devcontainer-linux.yml
+++ b/.github/workflows/devcontainer-linux.yml
@@ -16,7 +16,7 @@ jobs:
     name: Necessary?
     runs-on: ubuntu-24.04
     outputs:
-      build: ${{ steps.changed-files.outputs.all_changed_and_modified_files != '' }}
+      build: ${{ github.event_name == 'workflow_dispatch' || steps.changed-files.outputs.all_changed_and_modified_files != '' }}
       devcontainer-tag: ${{ steps.devcontainer-tag.outputs.tag }}
 
     steps:

--- a/.github/workflows/devcontainer-linux.yml
+++ b/.github/workflows/devcontainer-linux.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   necessary:
     name: Necessary?
-    runs-on: ["self-hosted", "build-server"]
+    runs-on: ubuntu-24.04
     outputs:
       build: ${{ steps.changed-files.outputs.all_changed_and_modified_files != '' }}
       devcontainer-tag: ${{ steps.devcontainer-tag.outputs.tag }}
@@ -49,7 +49,7 @@ jobs:
     if: ${{ needs.necessary.outputs.build == 'true' }}
     needs:
       - necessary
-    runs-on: ["self-hosted", "build-server"]
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout the code

--- a/.github/workflows/devcontainer-zephyr.yml
+++ b/.github/workflows/devcontainer-zephyr.yml
@@ -16,7 +16,7 @@ jobs:
     name: Necessary?
     runs-on: ubuntu-24.04
     outputs:
-      build: ${{ steps.changed-files.outputs.all_changed_and_modified_files != '' }}
+      build: ${{ github.event_name == 'workflow_dispatch' || steps.changed-files.outputs.all_changed_and_modified_files != '' }}
       devcontainer-tag: ${{ steps.devcontainer-tag.outputs.tag }}
 
     steps:

--- a/.github/workflows/devcontainer-zephyr.yml
+++ b/.github/workflows/devcontainer-zephyr.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   necessary:
     name: Necessary?
-    runs-on: ["self-hosted", "build-server"]
+    runs-on: ubuntu-24.04
     outputs:
       build: ${{ steps.changed-files.outputs.all_changed_and_modified_files != '' }}
       devcontainer-tag: ${{ steps.devcontainer-tag.outputs.tag }}
@@ -50,7 +50,7 @@ jobs:
     if: ${{ needs.necessary.outputs.build == 'true' }}
     needs:
       - necessary
-    runs-on: ["self-hosted", "build-server"]
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout the code

--- a/.github/workflows/formatting-checks.yml
+++ b/.github/workflows/formatting-checks.yml
@@ -20,7 +20,6 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/${{ github.repository }}/devcontainer-linux:${{ inputs.devcontainer-tag }}
-      options: --user 1000:1000
     steps:
       - name: Clean other workspace
         run: rm -rf ../.west

--- a/.github/workflows/formatting-checks.yml
+++ b/.github/workflows/formatting-checks.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   format-checks:
     name: Formatting checks
-    runs-on: ["self-hosted", "build-server"]
+    runs-on: ubuntu-24.04
     container:
       image: ghcr.io/${{ github.repository }}/devcontainer-linux:${{ inputs.devcontainer-tag }}
       options: --user 1000:1000

--- a/.github/workflows/formatting-checks.yml
+++ b/.github/workflows/formatting-checks.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Clean workspace
         run: find . -name . -o -prune -exec rm -rf -- {} +
 
-      - name: checkout
+      - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0

--- a/.github/workflows/formatting-checks.yml
+++ b/.github/workflows/formatting-checks.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Run C Format Checks
         run: sh scripts/check_c_formatting.sh
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,7 +20,6 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/${{ github.repository }}/devcontainer-linux:${{ inputs.devcontainer-tag }}
-      options: --user 1000:1000
     steps:
       - name: Clean other workspace
         run: rm -rf ../.west

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build-and-run-linux:
     name: Build and Run
-    runs-on: ["self-hosted", "build-server"]
+    runs-on: ubuntu-24.04
     container:
       image: ghcr.io/${{ github.repository }}/devcontainer-linux:${{ inputs.devcontainer-tag }}
       options: --user 1000:1000

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           submodules: true
 
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Configure (system tests)
         run: mkdir build && cd build && cmake ../tests/system/posix
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -74,6 +74,7 @@ jobs:
           path: build/coverage
 
       - name: Report code coverage
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: marocchino/sticky-pull-request-comment@v3
         with:
           GITHUB_TOKEN: ${{ secrets.TOKEN_WRITE_PR }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.repository }}-${{ github.workflow }}@main-${{ github.ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,7 @@ jobs:
 
   hardware-b_u585i_iot02a:
     name: Hardware b_u585i_iot02a
+    if: github.repository == 'project-ocre/ocre-runtime'
     needs:
       - zephyr-devcontainer
     uses: ./.github/workflows/hardware-bu585.yml

--- a/.github/workflows/zephyr-systests.yml
+++ b/.github/workflows/zephyr-systests.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   zephyr-systests:
     name: Build and Run System Tests
-    runs-on: ["self-hosted", "build-server"]
+    runs-on: ubuntu-24.04
     container:
       image: ghcr.io/${{ github.repository }}/devcontainer-zephyr:${{ inputs.devcontainer-tag }}
       options: --user 1000:1000

--- a/.github/workflows/zephyr-systests.yml
+++ b/.github/workflows/zephyr-systests.yml
@@ -41,6 +41,9 @@ jobs:
           path: ocre-runtime
           submodules: true
 
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE/ocre-runtime"
+
       - name: West init
         run: |
           . /opt/zephyr-venv/bin/activate

--- a/.github/workflows/zephyr-systests.yml
+++ b/.github/workflows/zephyr-systests.yml
@@ -20,7 +20,6 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/${{ github.repository }}/devcontainer-zephyr:${{ inputs.devcontainer-tag }}
-      options: --user 1000:1000
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -20,7 +20,6 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/${{ github.repository }}/devcontainer-zephyr:${{ inputs.devcontainer-tag }}
-      options: --user 1000:1000
     strategy:
       matrix:
         board:
@@ -83,7 +82,6 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/${{ github.repository }}/devcontainer-zephyr:${{ inputs.devcontainer-tag }}
-      options: --user 1000:1000
     strategy:
       matrix:
         board:

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build-zephyr:
     name: Build
-    runs-on: ["self-hosted", "build-server"]
+    runs-on: ubuntu-24.04
     container:
       image: ghcr.io/${{ github.repository }}/devcontainer-zephyr:${{ inputs.devcontainer-tag }}
       options: --user 1000:1000
@@ -80,7 +80,7 @@ jobs:
   run-zephyr:
     name: Run
     needs: build-zephyr
-    runs-on: ["self-hosted", "build-server"]
+    runs-on: ubuntu-24.04
     container:
       image: ghcr.io/${{ github.repository }}/devcontainer-zephyr:${{ inputs.devcontainer-tag }}
       options: --user 1000:1000

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -43,6 +43,9 @@ jobs:
           path: ocre-runtime
           submodules: true
 
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE/ocre-runtime"
+
       - name: West init
         run: |
           . /opt/zephyr-venv/bin/activate


### PR DESCRIPTION
Currently, all our jobs are running on private runners. Forks can't run any workflow. By implementing changes here, we are using public runners instead, exhaust our runners less and let forks to run their own CI checks.
Additionally, write tokens are only available locally, so while users can create their own token for local use, the upstream can't see it when PR is made from fork, as well as it doesn't use its own. Therefore, the fail-safe is necessary to only report coverage when secret exists. 

Additionally, currently following necessities forks have to perform to fully utilize CI:
- run main on dispatch first, to build devcontainers for their repo/org
- TOKEN_WRITE_PR PAT to their secrets to run coverage report ([proof](https://github.com/kr-t/ocre-runtime/pull/4))
- The hardware workflow is limited only to this project (if not checked, CI will wait till runner appears, even if runner doesn't exist)

As an extra bonus, I have noticed a noticeable speed increase for CI.